### PR TITLE
got rid off custom gridstack library version

### DIFF
--- a/client/app/_dashboards/dashboard.module.js
+++ b/client/app/_dashboards/dashboard.module.js
@@ -1,7 +1,7 @@
 window.d3 = require('d3');
-//TODO: check if released gridstack version visout lodash dependancy. If so, replace dependency in package.json (last checked version of the library is 0.4.0)
-import 'gridstack/src/gridstack.js';
-import 'gridstack/src/gridstack.jQueryUI.js';
+import 'gridstack/dist/gridstack.min';
+import 'gridstack/dist/jquery-ui.min';
+import 'gridstack/dist/gridstack.jQueryUI.min';
 import 'vendors/gridstack-angular.min';
 import 'vendors/pie-chart.min';
 import 'n3-charts/build/LineChart.min';

--- a/client/styles/vendors.scss
+++ b/client/styles/vendors.scss
@@ -2,8 +2,8 @@
 @import "../vendors/material-design-icons/iconfont/material-icons.css";
 @import "~font-awesome/css/font-awesome.min.css";
 @import "~angular-material/angular-material.min.css";
-@import "~gridstack/src/gridstack.scss";
-@import "~gridstack/src/gridstack-extra.scss";
+@import "~gridstack/dist/gridstack.min.css";
+@import "~gridstack/dist/gridstack-extra.min.css";
 @import "~ng-img-crop/compile/minified/ng-img-crop.css";
 @import "~textangular/dist/textAngular.css";
 @import "~md-date-range-picker/dist/md-date-range-picker.min.css";

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "echarts": "^4.6.0",
         "elasticsearch-browser": "^15.5.0",
         "font-awesome": "^4.7.0",
-        "gridstack": "git://github.com/danymill/gridstack.js.git#develop",
+        "gridstack": "^0.6.0",
         "highlight.js": "^9.18.0",
         "html2canvas": "^1.0.0-rc.5",
         "humanize-duration": "^3.21.0",


### PR DESCRIPTION
because of the version without `lodash` dependency was released