### PR TITLE
ZEB-515: hidden dashboard switcher displaying fix

### DIFF
--- a/client/app/core/config.route.js
+++ b/client/app/core/config.route.js
@@ -1,3 +1,4 @@
+// TODO: refactor redirections: create global "$rootScope.$on('$stateChangeError'..." handler inside a run() function
 (function () {
     'use strict';
 
@@ -38,9 +39,15 @@
                                         //TODO: dashboards is a home page. If we redirect to dashboards we can get infinity loop. We need to add simple error page;
                                         const message = rs && rs.message || `Can\'t fetch dashboard with id: ${dashboardId}`;
 
+                                        // Timeout to avoid digest issues
+                                        $timeout(() => {
+                                            const state = rs && rs.error && rs.error.status === 404 ? '404' : 'home';
+
+                                            $state.go(state);
+                                        }, 0, false);
                                         messageService.error(message);
 
-                                        return $q.reject(message);
+                                        return $q.reject({ message });
                                     }
                                 });
                             } else {

--- a/client/app/shared/modals/dashboard-settings-modal/dashboard-settings-modal.html
+++ b/client/app/shared/modals/dashboard-settings-modal/dashboard-settings-modal.html
@@ -28,7 +28,7 @@
                             <div ng-message="duplicateKey">Duplicate title forbidden</div>
                         </div>
                     </md-input-container>
-                    <div class="dashboard-dialog-container_hidden">
+                    <div class="dashboard-dialog-container_hidden" has-any-permission="['VIEW_HIDDEN_DASHBOARDS']">
                         <div class="dashboard-dialog-container_hidden_label">Hidden</div>
                         <md-switch class="md-primary" ng-model="dashboard.hidden" ng-change="!dashboard.hidden" ng-required aria-label="integr-switch" ng-disabled="!isNew && !dashboard.editable"></md-switch>
                     </div>


### PR DESCRIPTION
User should be able to create hidden dashboards only if he has `VIEW_HIDDEN_DASHBOARDS` permission. So, this fix displays/hides switcher depends on permission.

![image](https://user-images.githubusercontent.com/6594800/74524538-456cbc80-4f30-11ea-8181-895801a373a1.png)
